### PR TITLE
Add a downloads count column to the list of available custom modules

### DIFF
--- a/resources/views/module_update.phtml
+++ b/resources/views/module_update.phtml
@@ -134,7 +134,7 @@ use Jefferson49\Webtrees\Module\CustomModuleManager\RequestHandlers\ReleaseNotes
                     <?php if ($module !== null) : ?>
                         <?php $latest_version = $module_update_service->customModuleLatestVersion($fetch_latest) ?>
                     <?php else : ?>
-                        <?php $latest_version = '' ?>
+                        <?php $latest_version = $module_update_service->customModuleLatestVersion($fetch_latest) ?>
                         <?php $later_version_available = false ?>
                     <?php endif ?>
                     <?php $documentation_url = $module_update_service->documentationUrl() ?>

--- a/resources/views/module_update.phtml
+++ b/resources/views/module_update.phtml
@@ -78,6 +78,7 @@ use Jefferson49\Webtrees\Module\CustomModuleManager\RequestHandlers\ReleaseNotes
             null,
             null,
             null,
+            ['type' => 'num', 'searchable' => false],
             ['type' => 'html', 'searchable' => false],
             ['type' => 'html', 'searchable' => false],
             ['type' => 'html', 'searchable' => false],
@@ -96,6 +97,7 @@ use Jefferson49\Webtrees\Module\CustomModuleManager\RequestHandlers\ReleaseNotes
                 <th><?= I18N::translate('Current Version') ?></th>
                 <th><?= I18N::translate('Latest Version') ?></th>
                 <th><?= I18N::translate('Update Service') ?></th>
+                <th><?= I18N::translate('Downloads') ?></th>
                 <th><?= MoreI18N::xlate('Enabled') ?></th>
                 <th><?= I18N::translate('Install') ?></th>
                 <th><?= MoreI18N::xlate('Delete') ?></th>
@@ -238,6 +240,12 @@ use Jefferson49\Webtrees\Module\CustomModuleManager\RequestHandlers\ReleaseNotes
                     <!--Update Service -->
                     <td data-sort="<?= $module_update_service_name ?>">
                         <?= $module_update_service_name ?>
+                    </td>
+
+                    <!--Downloads -->
+                    <?php $download_count = ($module_update_service instanceof GithubModuleUpdate) ? $module_update_service->getDownloadCount() : -1 ?>
+                    <td data-sort="<?= $download_count ?>">
+                        <?= $download_count >= 0 ? number_format($download_count) : I18N::translate('N/A') ?>
                     </td>
 
                     <!-- Enabled -->

--- a/resources/views/module_update.phtml
+++ b/resources/views/module_update.phtml
@@ -32,6 +32,7 @@ use Jefferson49\Webtrees\Module\CustomModuleManager\RequestHandlers\ReleaseNotes
  * @var Collection          $themes
  * @var array               $module_names
  * @var bool                $fetch_latest
+ * @var bool                $fetch_all
  * @var string              $modules_to_show
  */
 
@@ -54,13 +55,23 @@ use Jefferson49\Webtrees\Module\CustomModuleManager\RequestHandlers\ReleaseNotes
     <div class="alert alert-warning" role="alert" style="white-space: pre-wrap;"><?= I18N::translate('A new version of "%s" is available. It is recommended to upgrade to the latest version before other custom modules are installed/upgraded.', $custom_module_manager->title()) ?></div>
 <?php endif ?>
 
-<?= I18N::translate('Typically, custom modules versions are updated every 24 hours. You can check if later versions are available.') ?><?= view('icons/spacer') ?></div><a href="<?= e(route(CustomModuleUpdatePage::class, [
+<?= I18N::translate('Typically, custom modules versions are updated every 24 hours. You can check if later versions are available.') ?>
+<?= view('icons/spacer') ?>
+<a href="<?= e(route(CustomModuleUpdatePage::class, [
         'fetch_latest' => true,
     ])) ?>" type="submit" class="btn btn-primary">
     <?= MoreI18N::xlate('check now') ?>
 </a>
-<div class="row mb-3"><?= view('icons/spacer') ?></div>
 
+<p class="mt-3">
+<?= I18N::translate('Fetch the latest version and download statistics for all modules (including not installed). This requires one API call per module and may take a moment.') ?>
+</p>
+<a href="<?= e(route(CustomModuleUpdatePage::class, [
+        'fetch_all' => true,
+    ])) ?>" type="submit" class="btn btn-secondary">
+    <?= I18N::translate('Fetch all') ?>
+</a>
+<div class="row mb-3"><?= view('icons/spacer') ?></div>
 
 <form method="post" action="<?= e(route(CustomModuleActivateAction::class)) ?>">
     <table
@@ -132,9 +143,9 @@ use Jefferson49\Webtrees\Module\CustomModuleManager\RequestHandlers\ReleaseNotes
                     <?php $category = $module_update_service->getCategory() ?>
                     <?php $current_version = $module_update_service->customModuleVersion() ?>
                     <?php if ($module !== null) : ?>
-                        <?php $latest_version = $module_update_service->customModuleLatestVersion($fetch_latest) ?>
+                        <?php $latest_version = $module_update_service->customModuleLatestVersion($fetch_latest || $fetch_all) ?>
                     <?php else : ?>
-                        <?php $latest_version = $module_update_service->customModuleLatestVersion($fetch_latest) ?>
+                        <?php $latest_version = $module_update_service->customModuleLatestVersion($fetch_all) ?>
                         <?php $later_version_available = false ?>
                     <?php endif ?>
                     <?php $documentation_url = $module_update_service->documentationUrl() ?>

--- a/src/CustomModuleManager.php
+++ b/src/CustomModuleManager.php
@@ -121,6 +121,8 @@ class CustomModuleManager extends AbstractModule implements
     public const PREF_SHOW_MENU_LIST_ITEM = 'show_menu_list_item';
     public const PREF_LATEST_VERSION      = 'latest';
     public const PREF_IGNORE_VERSION      = 'ignore';
+    public const PREF_DOWNLOAD_COUNT      = 'downloads';
+    public const PREF_DOWNLOAD_COUNT_TIME = 'downloads_time';
 
     //Configuraton
     public const CONFIG_GITHUB_BRANCH     = 'config';

--- a/src/CustomModuleManager.php
+++ b/src/CustomModuleManager.php
@@ -121,8 +121,6 @@ class CustomModuleManager extends AbstractModule implements
     public const PREF_SHOW_MENU_LIST_ITEM = 'show_menu_list_item';
     public const PREF_LATEST_VERSION      = 'latest';
     public const PREF_IGNORE_VERSION      = 'ignore';
-    public const PREF_DOWNLOAD_COUNT      = 'dl';
-    public const PREF_DOWNLOAD_COUNT_TIME = 'dl_t';
 
     //Configuraton
     public const CONFIG_GITHUB_BRANCH     = 'config';

--- a/src/CustomModuleManager.php
+++ b/src/CustomModuleManager.php
@@ -121,8 +121,8 @@ class CustomModuleManager extends AbstractModule implements
     public const PREF_SHOW_MENU_LIST_ITEM = 'show_menu_list_item';
     public const PREF_LATEST_VERSION      = 'latest';
     public const PREF_IGNORE_VERSION      = 'ignore';
-    public const PREF_DOWNLOAD_COUNT      = 'downloads';
-    public const PREF_DOWNLOAD_COUNT_TIME = 'downloads_time';
+    public const PREF_DOWNLOAD_COUNT      = 'dl';
+    public const PREF_DOWNLOAD_COUNT_TIME = 'dl_t';
 
     //Configuraton
     public const CONFIG_GITHUB_BRANCH     = 'config';

--- a/src/ModuleUpdates/GithubModuleUpdate.php
+++ b/src/ModuleUpdates/GithubModuleUpdate.php
@@ -276,6 +276,58 @@ class GithubModuleUpdate extends AbstractModuleUpdate implements CustomModuleUpd
     }
 
     /**
+     * Get the cached download count for this module.
+     * 
+     * Fetches the maximum download count across the latest 3 releases' assets.
+     * The result is cached for 24 hours using module preferences to avoid hitting 
+     * GitHub API rate limits on every page load.
+     *
+     * @return int  The download count, or -1 if unavailable
+     */
+    public function getDownloadCount(): int
+    {
+        $short_module_name = substr($this->module_name, 0, 25) . '_';
+        $cache_key = $short_module_name . CustomModuleManager::PREF_DOWNLOAD_COUNT;
+        $cache_time_key = $short_module_name . CustomModuleManager::PREF_DOWNLOAD_COUNT_TIME;
+
+        // Check if we have a cached value that is less than 24 hours old
+        $cached_time = (int) $this->custom_module_manager->getPreference($cache_time_key, '0');
+        $cached_count = $this->custom_module_manager->getPreference($cache_key, '');
+
+        if ($cached_count !== '' && (time() - $cached_time) < 86400) {
+            return (int) $cached_count;
+        }
+
+        // If the module does not provide releases, we cannot get download counts
+        if ($this->no_release) {
+            return -1;
+        }
+
+        $github_api_token = $this->custom_module_manager->getPreference(CustomModuleManager::PREF_GITHUB_API_TOKEN, '');
+
+        try {
+            $download_count = GithubService::getRecentReleasesMaxDownloads($this->github_repo, $github_api_token);
+
+            // Cache the result
+            $this->custom_module_manager->setPreference($cache_key, (string) $download_count);
+            $this->custom_module_manager->setPreference($cache_time_key, (string) time());
+
+            return $download_count;
+        } catch (GithubCommunicationError $ex) {
+            // If we have a stale cached value, return it rather than nothing
+            if ($cached_count !== '') {
+                return (int) $cached_count;
+            }
+
+            if (!CustomModuleManager::rememberGithubCommunciationError()) {
+                FlashMessages::addMessage(I18N::translate('Communication error with %s', self::NAME), 'danger');
+            }
+
+            return -1;
+        }
+    }
+
+    /**
      * Get the latest release URL
      *
      * @return string

--- a/src/ModuleUpdates/GithubModuleUpdate.php
+++ b/src/ModuleUpdates/GithubModuleUpdate.php
@@ -219,7 +219,10 @@ class GithubModuleUpdate extends AbstractModuleUpdate implements CustomModuleUpd
         // This also populates the download count cache as a side effect (piggybacking)
         elseif ($latest_version === '' && $this->github_repo !== '') {
 
-            $latest_version = $this->fetchReleasesInfoCached($fetch_latest)['tag'];
+            // Only fetch from GitHub if explicitly requested (fetch_latest=true or fetch_all)
+            // Otherwise, just read from cache (returns empty if not yet fetched)
+            $info = $this->fetchReleasesInfoCached($fetch_latest);
+            $latest_version = $info['tag'];
         }
 
         if ($module !== null) {
@@ -270,10 +273,9 @@ class GithubModuleUpdate extends AbstractModuleUpdate implements CustomModuleUpd
     /**
      * Get the cached download count for this module.
      * 
-     * Fetches the maximum download count across the latest 3 releases' assets.
-     * Uses the webtrees file cache (24h TTL). For modules where the version check
-     * goes through the combined GitHub call, the download count is piggybacked
-     * (no extra API call needed).
+     * Returns the download count from the file cache. The cache is only populated
+     * when the user explicitly triggers a fetch (via the "Fetch versions & downloads" button).
+     * Returns -1 if no cached data is available.
      *
      * @return int  The download count, or -1 if unavailable
      */
@@ -284,6 +286,7 @@ class GithubModuleUpdate extends AbstractModuleUpdate implements CustomModuleUpd
             return -1;
         }
 
+        // Only read from cache — never trigger an API call automatically
         return $this->fetchReleasesInfoCached(false)['max_downloads'];
     }
 
@@ -292,34 +295,42 @@ class GithubModuleUpdate extends AbstractModuleUpdate implements CustomModuleUpd
      * using the webtrees file cache.
      * 
      * This method fetches /releases?per_page=3 and caches both the latest version tag
-     * and the maximum download count across the 3 most recent releases. This allows
-     * piggybacking download counts on version checks without extra API calls.
+     * and the maximum download count across the 3 most recent releases. The cache uses
+     * no explicit TTL (persists until manually refreshed or garbage collected).
+     * 
+     * The cache is only populated when explicitly requested by the user via the
+     * "Fetch versions & downloads" button. On normal page loads, only cached data is read.
      *
-     * @param bool $force_refresh  Whether to invalidate the cache before fetching
+     * @param bool $force_refresh  Whether to invalidate the cache and fetch fresh data from GitHub
      * 
      * @return array{tag: string, max_downloads: int}
      */
-    private function fetchReleasesInfoCached(bool $force_refresh = false): array
+    public function fetchReleasesInfoCached(bool $force_refresh = false): array
     {
         $cache_key = 'cmm-releases-' . md5($this->github_repo);
 
         if ($force_refresh) {
             Registry::cache()->file()->forget($cache_key);
+
+            return Registry::cache()->file()->remember($cache_key, function (): array {
+                $github_api_token = $this->custom_module_manager->getPreference(CustomModuleManager::PREF_GITHUB_API_TOKEN, '');
+
+                try {
+                    return GithubService::getRecentReleasesInfo($this->github_repo, $github_api_token);
+                } catch (GithubCommunicationError $ex) {
+                    if (!CustomModuleManager::rememberGithubCommunciationError()) {
+                        FlashMessages::addMessage(I18N::translate('Communication error with %s', self::NAME), 'danger');
+                    }
+
+                    return ['tag' => '', 'max_downloads' => -1];
+                }
+            });
         }
 
+        // Read-only: return cached data or defaults if nothing cached yet
         return Registry::cache()->file()->remember($cache_key, function (): array {
-            $github_api_token = $this->custom_module_manager->getPreference(CustomModuleManager::PREF_GITHUB_API_TOKEN, '');
-
-            try {
-                return GithubService::getRecentReleasesInfo($this->github_repo, $github_api_token);
-            } catch (GithubCommunicationError $ex) {
-                if (!CustomModuleManager::rememberGithubCommunciationError()) {
-                    FlashMessages::addMessage(I18N::translate('Communication error with %s', self::NAME), 'danger');
-                }
-
-                return ['tag' => '', 'max_downloads' => -1];
-            }
-        }, 86400);
+            return ['tag' => '', 'max_downloads' => -1];
+        });
     }
 
     /**

--- a/src/ModuleUpdates/GithubModuleUpdate.php
+++ b/src/ModuleUpdates/GithubModuleUpdate.php
@@ -34,6 +34,7 @@ namespace Jefferson49\Webtrees\Module\CustomModuleManager\ModuleUpdates;
 use Fisharebest\Webtrees\FlashMessages;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Module\ModuleInterface;
+use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Services\ModuleService;
 use Jefferson49\Webtrees\Exceptions\GithubCommunicationError;
 use Jefferson49\Webtrees\Helpers\GithubService;
@@ -214,20 +215,11 @@ class GithubModuleUpdate extends AbstractModuleUpdate implements CustomModuleUpd
 
             $latest_version =  self::getLatestVersionByUpdateURL($module);
         }
-        // Otherwise, try to get the latest version from Github
+        // Otherwise, try to get the latest version from Github using the combined call
+        // This also populates the download count cache as a side effect (piggybacking)
         elseif ($latest_version === '' && $this->github_repo !== '') {
 
-            $github_api_token = $this->custom_module_manager->getPreference(CustomModuleManager::PREF_GITHUB_API_TOKEN, '');       
-
-            try {
-                $latest_version = GithubService::getLatestReleaseTag($this->github_repo, $github_api_token);
-            }
-            catch (GithubCommunicationError $ex) {
-                // Can't connect to GitHub? 
-                    if (!CustomModuleManager::rememberGithubCommunciationError()) {
-                    FlashMessages::addMessage(I18N::translate('Communication error with %s', self::NAME), 'danger');
-                }
-            }
+            $latest_version = $this->fetchReleasesInfoCached($fetch_latest)['tag'];
         }
 
         if ($module !== null) {
@@ -279,52 +271,55 @@ class GithubModuleUpdate extends AbstractModuleUpdate implements CustomModuleUpd
      * Get the cached download count for this module.
      * 
      * Fetches the maximum download count across the latest 3 releases' assets.
-     * The result is cached for 24 hours using module preferences to avoid hitting 
-     * GitHub API rate limits on every page load.
+     * Uses the webtrees file cache (24h TTL). For modules where the version check
+     * goes through the combined GitHub call, the download count is piggybacked
+     * (no extra API call needed).
      *
      * @return int  The download count, or -1 if unavailable
      */
     public function getDownloadCount(): int
     {
-        $short_module_name = substr($this->module_name, 0, 25) . '_';
-        $cache_key = $short_module_name . CustomModuleManager::PREF_DOWNLOAD_COUNT;
-        $cache_time_key = $short_module_name . CustomModuleManager::PREF_DOWNLOAD_COUNT_TIME;
-
-        // Check if we have a cached value that is less than 24 hours old
-        $cached_time = (int) $this->custom_module_manager->getPreference($cache_time_key, '0');
-        $cached_count = $this->custom_module_manager->getPreference($cache_key, '');
-
-        if ($cached_count !== '' && (time() - $cached_time) < 86400) {
-            return (int) $cached_count;
-        }
-
         // If the module does not provide releases, we cannot get download counts
         if ($this->no_release) {
             return -1;
         }
 
-        $github_api_token = $this->custom_module_manager->getPreference(CustomModuleManager::PREF_GITHUB_API_TOKEN, '');
+        return $this->fetchReleasesInfoCached(false)['max_downloads'];
+    }
 
-        try {
-            $download_count = GithubService::getRecentReleasesMaxDownloads($this->github_repo, $github_api_token);
+    /**
+     * Fetch combined release information (version tag + download count) from GitHub,
+     * using the webtrees file cache.
+     * 
+     * This method fetches /releases?per_page=3 and caches both the latest version tag
+     * and the maximum download count across the 3 most recent releases. This allows
+     * piggybacking download counts on version checks without extra API calls.
+     *
+     * @param bool $force_refresh  Whether to invalidate the cache before fetching
+     * 
+     * @return array{tag: string, max_downloads: int}
+     */
+    private function fetchReleasesInfoCached(bool $force_refresh = false): array
+    {
+        $cache_key = 'cmm-releases-' . md5($this->github_repo);
 
-            // Cache the result
-            $this->custom_module_manager->setPreference($cache_key, (string) $download_count);
-            $this->custom_module_manager->setPreference($cache_time_key, (string) time());
-
-            return $download_count;
-        } catch (GithubCommunicationError $ex) {
-            // If we have a stale cached value, return it rather than nothing
-            if ($cached_count !== '') {
-                return (int) $cached_count;
-            }
-
-            if (!CustomModuleManager::rememberGithubCommunciationError()) {
-                FlashMessages::addMessage(I18N::translate('Communication error with %s', self::NAME), 'danger');
-            }
-
-            return -1;
+        if ($force_refresh) {
+            Registry::cache()->file()->forget($cache_key);
         }
+
+        return Registry::cache()->file()->remember($cache_key, function (): array {
+            $github_api_token = $this->custom_module_manager->getPreference(CustomModuleManager::PREF_GITHUB_API_TOKEN, '');
+
+            try {
+                return GithubService::getRecentReleasesInfo($this->github_repo, $github_api_token);
+            } catch (GithubCommunicationError $ex) {
+                if (!CustomModuleManager::rememberGithubCommunciationError()) {
+                    FlashMessages::addMessage(I18N::translate('Communication error with %s', self::NAME), 'danger');
+                }
+
+                return ['tag' => '', 'max_downloads' => -1];
+            }
+        }, 86400);
     }
 
     /**

--- a/src/RequestHandlers/CustomModuleUpdatePage.php
+++ b/src/RequestHandlers/CustomModuleUpdatePage.php
@@ -64,6 +64,7 @@ class CustomModuleUpdatePage implements RequestHandlerInterface
         $tree         = Validator::attributes($request)->treeOptional();
         $user         = Validator::attributes($request)->user();
         $fetch_latest = Validator::queryParams($request)->boolean('fetch_latest', false);
+        $fetch_all    = Validator::queryParams($request)->boolean('fetch_all', false);
 
         // If no administrator, redirect to home page
         if (!($user instanceof User) OR !Auth::isAdmin($user)) {
@@ -84,6 +85,7 @@ class CustomModuleUpdatePage implements RequestHandlerInterface
             'custom_modules'             => $module_service->findByInterface(ModuleCustomInterface::class, true),
             'themes'                     => $module_service->findByInterface(ModuleThemeInterface::class, true),
             'fetch_latest'               => $fetch_latest,
+            'fetch_all'                  => $fetch_all,
             'modules_to_show'            => $custom_module_manager->getPreference(CustomModuleManager::PREF_MODULES_TO_SHOW, CustomModuleManager::PREF_SHOW_ALL),
         ]);
     }


### PR DESCRIPTION
This is proposal to address #55:
* retrieves the downloads count with github API (max number of downloades of the last three releases to normalize data / account for new releases)
* caches the data using module settings
* shows the download count in the table (sortable)

Screenshot:
<img width="2176" height="1668" alt="Image" src="https://github.com/user-attachments/assets/af0ed705-bd6c-4973-8968-046c6e14b674" />